### PR TITLE
scripts: Update VKSC loader to API v1.0.12

### DIFF
--- a/loader/generated-vksc/loader_generated_header_version.cmake
+++ b/loader/generated-vksc/loader_generated_header_version.cmake
@@ -7,7 +7,7 @@
 # Copyright (c) 2021 Valve Corporation
 # Copyright (c) 2021 LunarG, Inc.
 # Copyright (c) 2021 Google Inc.
-# Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -25,5 +25,5 @@
 #
 ############################################################################
 
-set(LOADER_GENERATED_HEADER_VERSION "1.0.11")
+set(LOADER_GENERATED_HEADER_VERSION "1.0.12")
 

--- a/loader/generated-vksc/vk_dispatch_table_helper.h
+++ b/loader/generated-vksc/vk_dispatch_table_helper.h
@@ -6,7 +6,7 @@
  * Copyright (c) 2015-2017 The Khronos Group Inc.
  * Copyright (c) 2015-2017 Valve Corporation
  * Copyright (c) 2015-2017 LunarG, Inc.
- * Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -116,9 +116,6 @@ static VKAPI_ATTR void VKAPI_CALL StubCmdSetPrimitiveRestartEnableEXT(VkCommandB
 static VKAPI_ATTR void VKAPI_CALL StubCmdSetColorWriteEnableEXT(VkCommandBuffer       commandBuffer, uint32_t                                attachmentCount, const VkBool32*   pColorWriteEnables) {  };
 #ifdef VK_USE_PLATFORM_SCI
 static VKAPI_ATTR VkResult VKAPI_CALL StubCreateSemaphoreSciSyncPoolNV(VkDevice device, const VkSemaphoreSciSyncPoolCreateInfoNV* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkSemaphoreSciSyncPoolNV* pSemaphorePool) { return VK_SUCCESS; };
-#endif // VK_USE_PLATFORM_SCI
-#ifdef VK_USE_PLATFORM_SCI
-static VKAPI_ATTR void VKAPI_CALL StubDestroySemaphoreSciSyncPoolNV(VkDevice device, VkSemaphoreSciSyncPoolNV semaphorePool, const VkAllocationCallbacks* pAllocator) {  };
 #endif // VK_USE_PLATFORM_SCI
 
 
@@ -428,10 +425,6 @@ static inline void layer_init_device_dispatch_table(VkDevice device, VkLayerDisp
 #ifdef VK_USE_PLATFORM_SCI
     table->CreateSemaphoreSciSyncPoolNV = (PFN_vkCreateSemaphoreSciSyncPoolNV) gpa(device, "vkCreateSemaphoreSciSyncPoolNV");
     if (table->CreateSemaphoreSciSyncPoolNV == nullptr) { table->CreateSemaphoreSciSyncPoolNV = (PFN_vkCreateSemaphoreSciSyncPoolNV)StubCreateSemaphoreSciSyncPoolNV; }
-#endif // VK_USE_PLATFORM_SCI
-#ifdef VK_USE_PLATFORM_SCI
-    table->DestroySemaphoreSciSyncPoolNV = (PFN_vkDestroySemaphoreSciSyncPoolNV) gpa(device, "vkDestroySemaphoreSciSyncPoolNV");
-    if (table->DestroySemaphoreSciSyncPoolNV == nullptr) { table->DestroySemaphoreSciSyncPoolNV = (PFN_vkDestroySemaphoreSciSyncPoolNV)StubDestroySemaphoreSciSyncPoolNV; }
 #endif // VK_USE_PLATFORM_SCI
 }
 

--- a/loader/generated-vksc/vk_layer_dispatch_table.h
+++ b/loader/generated-vksc/vk_layer_dispatch_table.h
@@ -5,7 +5,7 @@
  * Copyright (c) 2015-2017 The Khronos Group Inc.
  * Copyright (c) 2015-2017 Valve Corporation
  * Copyright (c) 2015-2017 LunarG, Inc.
- * Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -430,9 +430,6 @@ typedef struct VkLayerDispatchTable_ {
     // ---- VK_NV_external_sci_sync2 extension commands
 #ifdef VK_USE_PLATFORM_SCI
     PFN_vkCreateSemaphoreSciSyncPoolNV CreateSemaphoreSciSyncPoolNV;
-#endif // VK_USE_PLATFORM_SCI
-#ifdef VK_USE_PLATFORM_SCI
-    PFN_vkDestroySemaphoreSciSyncPoolNV DestroySemaphoreSciSyncPoolNV;
 #endif // VK_USE_PLATFORM_SCI
 } VkLayerDispatchTable;
 

--- a/loader/generated-vksc/vk_loader_extensions.c
+++ b/loader/generated-vksc/vk_loader_extensions.c
@@ -5,7 +5,7 @@
  * Copyright (c) 2015-2017 The Khronos Group Inc.
  * Copyright (c) 2015-2017 Valve Corporation
  * Copyright (c) 2015-2017 LunarG, Inc.
- * Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -484,9 +484,6 @@ VKAPI_ATTR void VKAPI_CALL loader_init_device_extension_dispatch_table(struct lo
 #ifdef VK_USE_PLATFORM_SCI
     table->CreateSemaphoreSciSyncPoolNV = (PFN_vkCreateSemaphoreSciSyncPoolNV)gdpa(dev, "vkCreateSemaphoreSciSyncPoolNV");
 #endif // VK_USE_PLATFORM_SCI
-#ifdef VK_USE_PLATFORM_SCI
-    table->DestroySemaphoreSciSyncPoolNV = (PFN_vkDestroySemaphoreSciSyncPoolNV)gdpa(dev, "vkDestroySemaphoreSciSyncPoolNV");
-#endif // VK_USE_PLATFORM_SCI
 }
 
 // Init Instance function pointer dispatch table with core commands
@@ -894,9 +891,6 @@ VKAPI_ATTR void* VKAPI_CALL loader_lookup_device_dispatch_table(const VkLayerDis
     // ---- VK_NV_external_sci_sync2 extension commands
 #ifdef VK_USE_PLATFORM_SCI
     if (!strcmp(name, "CreateSemaphoreSciSyncPoolNV")) return (void *)table->CreateSemaphoreSciSyncPoolNV;
-#endif // VK_USE_PLATFORM_SCI
-#ifdef VK_USE_PLATFORM_SCI
-    if (!strcmp(name, "DestroySemaphoreSciSyncPoolNV")) return (void *)table->DestroySemaphoreSciSyncPoolNV;
 #endif // VK_USE_PLATFORM_SCI
 
     return NULL;
@@ -2028,16 +2022,6 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSemaphoreSciSyncPoolNV(
 }
 
 #endif // VK_USE_PLATFORM_SCI
-#ifdef VK_USE_PLATFORM_SCI
-VKAPI_ATTR void VKAPI_CALL DestroySemaphoreSciSyncPoolNV(
-    VkDevice                                    device,
-    VkSemaphoreSciSyncPoolNV                    semaphorePool,
-    const VkAllocationCallbacks*                pAllocator) {
-    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
-    disp->DestroySemaphoreSciSyncPoolNV(device, semaphorePool, pAllocator);
-}
-
-#endif // VK_USE_PLATFORM_SCI
 // GPA helpers for extensions
 bool extension_instance_gpa(struct loader_instance *ptr_instance, const char *name, void **addr) {
     *addr = NULL;
@@ -2463,12 +2447,6 @@ bool extension_instance_gpa(struct loader_instance *ptr_instance, const char *na
 #ifdef VK_USE_PLATFORM_SCI
     if (!strcmp("vkCreateSemaphoreSciSyncPoolNV", name)) {
         *addr = (void *)CreateSemaphoreSciSyncPoolNV;
-        return true;
-    }
-#endif // VK_USE_PLATFORM_SCI
-#ifdef VK_USE_PLATFORM_SCI
-    if (!strcmp("vkDestroySemaphoreSciSyncPoolNV", name)) {
-        *addr = (void *)DestroySemaphoreSciSyncPoolNV;
         return true;
     }
 #endif // VK_USE_PLATFORM_SCI

--- a/loader/generated-vksc/vk_loader_extensions.h
+++ b/loader/generated-vksc/vk_loader_extensions.h
@@ -5,7 +5,7 @@
  * Copyright (c) 2015-2017 The Khronos Group Inc.
  * Copyright (c) 2015-2017 Valve Corporation
  * Copyright (c) 2015-2017 LunarG, Inc.
- * Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/generated/loader_generated_header_version.cmake
+++ b/loader/generated/loader_generated_header_version.cmake
@@ -7,7 +7,7 @@
 # Copyright (c) 2021 Valve Corporation
 # Copyright (c) 2021 LunarG, Inc.
 # Copyright (c) 2021 Google Inc.
-# Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/loader/generated/vk_dispatch_table_helper.h
+++ b/loader/generated/vk_dispatch_table_helper.h
@@ -6,7 +6,7 @@
  * Copyright (c) 2015-2017 The Khronos Group Inc.
  * Copyright (c) 2015-2017 Valve Corporation
  * Copyright (c) 2015-2017 LunarG, Inc.
- * Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/generated/vk_layer_dispatch_table.h
+++ b/loader/generated/vk_layer_dispatch_table.h
@@ -5,7 +5,7 @@
  * Copyright (c) 2015-2017 The Khronos Group Inc.
  * Copyright (c) 2015-2017 Valve Corporation
  * Copyright (c) 2015-2017 LunarG, Inc.
- * Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/generated/vk_loader_extensions.c
+++ b/loader/generated/vk_loader_extensions.c
@@ -5,7 +5,7 @@
  * Copyright (c) 2015-2017 The Khronos Group Inc.
  * Copyright (c) 2015-2017 Valve Corporation
  * Copyright (c) 2015-2017 LunarG, Inc.
- * Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/generated/vk_loader_extensions.h
+++ b/loader/generated/vk_loader_extensions.h
@@ -5,7 +5,7 @@
  * Copyright (c) 2015-2017 The Khronos Group Inc.
  * Copyright (c) 2015-2017 Valve Corporation
  * Copyright (c) 2015-2017 LunarG, Inc.
- * Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/scripts/dispatch_table_helper_generator.py
+++ b/scripts/dispatch_table_helper_generator.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2015-2017 Valve Corporation
 # Copyright (c) 2015-2017 LunarG, Inc.
 # Copyright (c) 2015-2017 Google Inc.
-# Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -111,7 +111,7 @@ class DispatchTableHelperOutputGenerator(OutputGenerator):
         copyright += ' * Copyright (c) 2015-2017 The Khronos Group Inc.\n'
         copyright += ' * Copyright (c) 2015-2017 Valve Corporation\n'
         copyright += ' * Copyright (c) 2015-2017 LunarG, Inc.\n'
-        copyright += ' * Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n'
+        copyright += ' * Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n'
         copyright += ' *\n'
         copyright += ' * Licensed under the Apache License, Version 2.0 (the "License");\n'
         copyright += ' * you may not use this file except in compliance with the License.\n'

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -15,9 +15,9 @@
             "build_dir" : "VulkanSC-Headers/build",
             "install_dir" : "VulkanSC-Headers/build/install",
             "cmake_options" : [
-              "-DVulkanSC=TRUE"
+              "-DVULKANSC=ON"
             ],
-            "commit" : "vksc1.0.11"
+            "commit" : "vksc1.0.12"
         },
         {
             "name": "googletest",

--- a/scripts/loader_extension_generator.py
+++ b/scripts/loader_extension_generator.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2015-2020 Valve Corporation
 # Copyright (c) 2015-2020 LunarG, Inc.
 # Copyright (c) 2015-2017 Google Inc.
-# Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -189,7 +189,7 @@ class LoaderExtensionOutputGenerator(OutputGenerator):
         copyright += ' * Copyright (c) 2015-2017 The Khronos Group Inc.\n'
         copyright += ' * Copyright (c) 2015-2017 Valve Corporation\n'
         copyright += ' * Copyright (c) 2015-2017 LunarG, Inc.\n'
-        copyright += ' * Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n'
+        copyright += ' * Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n'
         copyright += ' *\n'
         copyright += ' * Licensed under the Apache License, Version 2.0 (the "License");\n'
         copyright += ' * you may not use this file except in compliance with the License.\n'

--- a/scripts/loader_versioning_generator.py
+++ b/scripts/loader_versioning_generator.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2021 Valve Corporation
 # Copyright (c) 2021 LunarG, Inc.
 # Copyright (c) 2021 Google Inc.
-# Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -127,7 +127,7 @@ class LoaderVersioningGenerator(OutputGenerator):
 # Copyright (c) 2021 Valve Corporation
 # Copyright (c) 2021 LunarG, Inc.
 # Copyright (c) 2021 Google Inc.
-# Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Change updates loader scripts to sync the v1.0.12 Vulkan SC headers and makes the necessary updates to build against them. Also update copyright headers as appropriate.