### PR TITLE
Updates for VulkanSC-Headers compatibility

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -19,4 +19,6 @@
 loader/generated/*.c text eol=lf
 loader/generated/*.h text eol=lf
 loader/generated/*.cmake text eol=lf
-
+loader/generated-vksc/*.c text eol=lf
+loader/generated-vksc/*.h text eol=lf
+loader/generated-vksc/*.cmake text eol=lf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
               if: matrix.vksc_build == 'VULKANSC=OFF'
 
             - name: Verify generated source files
-              run: python scripts/generate_source.py --api vulkansc --verify external/VulkanSC-Headers/registry
+              run: python scripts/generate_source.py --api vulkansc --verify external/Vulkan-Headers/registry
               if: matrix.vksc_build == 'VULKANSC=ON'
 
             - name: Verify code formatting with clang-format

--- a/BUILD.md
+++ b/BUILD.md
@@ -186,6 +186,9 @@ then be regenerated using `scripts/generate_source.py`:
 
     python3 scripts/generate_source.py PATH_TO_VULKAN_HEADERS_REGISTRY_DIR
 
+To generate source code for Vulkan SC the `--api vulkansc` option must be
+passed to the `generate_source.py` command.
+
 A helper CMake target `VulkanLoader_generated_source` is also provided to simplify
 the invocation of `scripts/generate_source.py` from the build directory:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Vulkan and Vulkan SC Ecosystem Components
 
-This project provides the Khronos Vulkan ICD Desktop loader for Windows, Linux, and MacOS, and
+This project provides the Khronos Vulkan SC ICD Desktop loader for Windows, Linux, and MacOS, and
 the Khronos Vulkan SC Development ICD loader for Windows, Linux, and QNX.
+
+> **IMPORTANT NOTE:** This repository is to be used with the [Vulkan SC](https://www.khronos.org/vulkansc/) API and should not be confused with the similar repository that exists for the Vulkan API (see https://github.com/KhronosGroup/Vulkan-Loader). While it is possible to build the Vulkan version from this repository, this repository contains a forked version of the upstream code and may not be up-to-date with the latest changes in the upstream repository.
 
 ## CI Build Status
 

--- a/cmake/FindVulkanHeaders.cmake
+++ b/cmake/FindVulkanHeaders.cmake
@@ -64,15 +64,15 @@ if(DEFINED VULKAN_HEADERS_INSTALL_DIR)
   # searching system environment variables like $PATH that may
   # contain SDK directories.
   if(VULKANSC)
-      find_path(VulkanHeaders_INCLUDE_DIR
-          NAMES vulkan/vulkan_sc.h
-          HINTS ${VULKAN_HEADERS_INSTALL_DIR}/include
-          NO_CMAKE_FIND_ROOT_PATH)
+    find_path(VulkanHeaders_INCLUDE_DIR
+        NAMES vulkan/vulkan_sc.h
+        HINTS ${VULKAN_HEADERS_INSTALL_DIR}/include
+        NO_CMAKE_FIND_ROOT_PATH)
   else()
-      find_path(VulkanHeaders_INCLUDE_DIR
-          NAMES vulkan/vulkan.h
-          HINTS ${VULKAN_HEADERS_INSTALL_DIR}/include
-          NO_CMAKE_FIND_ROOT_PATH)
+    find_path(VulkanHeaders_INCLUDE_DIR
+        NAMES vulkan/vulkan.h
+        HINTS ${VULKAN_HEADERS_INSTALL_DIR}/include
+        NO_CMAKE_FIND_ROOT_PATH)
   endif()
   find_path(VulkanRegistry_DIR
       NAMES vk.xml
@@ -107,19 +107,15 @@ set(VulkanHeaders_VERSION_MAJOR "0")
 set(VulkanHeaders_VERSION_MINOR "0")
 set(VulkanHeaders_VERSION_PATCH "0")
 
-if(VULKANSC)
-    if (EXISTS "${VulkanHeaders_INCLUDE_DIR}/vulkan/vulkan_sc_core.h")
-        set(VulkanHeaders_main_header ${VulkanHeaders_INCLUDE_DIR}/vulkan/vulkan_sc_core.h)
-    endif()
-else()
+if (EXISTS "${VulkanHeaders_INCLUDE_DIR}/vulkan/vulkan_sc_core.h")
+    set(VulkanHeaders_main_header ${VulkanHeaders_INCLUDE_DIR}/vulkan/vulkan_sc_core.h)
 # First, determine which header we need to grab the version information from.
 # Starting with Vulkan 1.1, we should use vulkan_core.h, but prior to that,
 # the information was in vulkan.h.
-    if (EXISTS "${VulkanHeaders_INCLUDE_DIR}/vulkan/vulkan_core.h")
-        set(VulkanHeaders_main_header ${VulkanHeaders_INCLUDE_DIR}/vulkan/vulkan_core.h)
-    else()
-        set(VulkanHeaders_main_header ${VulkanHeaders_INCLUDE_DIR}/vulkan/vulkan.h)
-    endif()
+elseif (EXISTS "${VulkanHeaders_INCLUDE_DIR}/vulkan/vulkan_core.h")
+    set(VulkanHeaders_main_header ${VulkanHeaders_INCLUDE_DIR}/vulkan/vulkan_core.h)
+else()
+    set(VulkanHeaders_main_header ${VulkanHeaders_INCLUDE_DIR}/vulkan/vulkan.h)
 endif()
 
 # Find all lines in the header file that contain any version we may be interested in

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -3,6 +3,7 @@
 # Copyright (c) 2014-2021 Valve Corporation
 # Copyright (c) 2014-2021 LunarG, Inc.
 # Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023-2023 RasterGrid Kft.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -362,47 +363,36 @@ else()
         find_library(COREFOUNDATION_LIBRARY NAMES CoreFoundation)
         target_link_libraries(${SONAME} "-framework CoreFoundation")
 
+        # Build vulkan.framework
+        set(FRAMEWORK_HEADERS
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vk_icd.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vk_layer.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vk_platform.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_android.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_ios.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_macos.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_vi.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_wayland.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_win32.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_xcb.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_xlib.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_xlib_xrandr.h
+            ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_screen.h)
         if(VULKANSC)
-            # Build vulkansc.framework
-            set(FRAMEWORK_HEADERS
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vk_icd.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vk_layer.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vk_platform.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vk_sdk_platform.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_android.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_sc_core.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_sc_core.hpp
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_ios.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_macos.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_sci.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_vi.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_wayland.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_win32.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_xcb.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_xlib.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_xlib_xrandr.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_screen.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_sc.h)
-        else()
-            # Build vulkan.framework
-            set(FRAMEWORK_HEADERS
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vk_icd.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vk_layer.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vk_platform.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vk_sdk_platform.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_android.h
+            list(APPEND FRAMEWORK_HEADERS
+                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_sc.h
+                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_sci.h)
+            if (EXISTS "${VulkanHeaders_INCLUDE_DIR}/vulkan/vulkan_sc_core.h")
+                list(APPEND FRAMEWORK_HEADERS ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_sc_core.h)
+            endif()
+        endif()
+        if (EXISTS "${VulkanHeaders_INCLUDE_DIR}/vulkan/vulkan.h")
+            list(APPEND FRAMEWORK_HEADERS
                 ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_core.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_ios.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_macos.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_vi.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_wayland.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_win32.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_xcb.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_xlib.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_xlib_xrandr.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan_screen.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan.h
-                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan.hpp)
+                ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan.h)
+            if (EXISTS "${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan.hpp")
+                list(APPEND FRAMEWORK_HEADERS ${VulkanHeaders_INCLUDE_DIRS}/vulkan/vulkan.hpp)
+            endif()
         endif()
         if(BUILD_STATIC_LOADER)
             add_library(${SONAME}-framework STATIC ${NORMAL_LOADER_SRCS} ${OPT_LOADER_SRCS} ${FRAMEWORK_HEADERS})

--- a/loader/CMakeLists.txt
+++ b/loader/CMakeLists.txt
@@ -79,6 +79,10 @@ elseif(UNIX AND NOT APPLE) # i.e.: Linux
     endif()
 
     if(VULKANSC)
+        if(BUILD_WSI_SCREEN_QNX_SUPPORT)
+            set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS VK_USE_PLATFORM_SCREEN_QNX)
+        endif()
+
         if(BUILD_WSI_SCI_SUPPORT)
             set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS VK_USE_PLATFORM_SCI)
         endif()

--- a/loader/generated-vksc/vk_dispatch_table_helper.h
+++ b/loader/generated-vksc/vk_dispatch_table_helper.h
@@ -120,6 +120,9 @@ static VKAPI_ATTR void VKAPI_CALL StubCmdSetColorWriteEnableEXT(VkCommandBuffer 
 #ifdef VK_USE_PLATFORM_SCI
 static VKAPI_ATTR VkResult VKAPI_CALL StubCreateSemaphoreSciSyncPoolNV(VkDevice device, const VkSemaphoreSciSyncPoolCreateInfoNV* pCreateInfo, const VkAllocationCallbacks* pAllocator, VkSemaphoreSciSyncPoolNV* pSemaphorePool) { return VK_SUCCESS; };
 #endif // VK_USE_PLATFORM_SCI
+#ifdef VK_USE_PLATFORM_SCREEN_QNX
+static VKAPI_ATTR VkResult VKAPI_CALL StubGetScreenBufferPropertiesQNX(VkDevice device, const struct _screen_buffer* buffer, VkScreenBufferPropertiesQNX* pProperties) { return VK_SUCCESS; };
+#endif // VK_USE_PLATFORM_SCREEN_QNX
 
 
 
@@ -433,6 +436,10 @@ static inline void layer_init_device_dispatch_table(VkDevice device, VkLayerDisp
     table->CreateSemaphoreSciSyncPoolNV = (PFN_vkCreateSemaphoreSciSyncPoolNV) gpa(device, "vkCreateSemaphoreSciSyncPoolNV");
     if (table->CreateSemaphoreSciSyncPoolNV == nullptr) { table->CreateSemaphoreSciSyncPoolNV = (PFN_vkCreateSemaphoreSciSyncPoolNV)StubCreateSemaphoreSciSyncPoolNV; }
 #endif // VK_USE_PLATFORM_SCI
+#ifdef VK_USE_PLATFORM_SCREEN_QNX
+    table->GetScreenBufferPropertiesQNX = (PFN_vkGetScreenBufferPropertiesQNX) gpa(device, "vkGetScreenBufferPropertiesQNX");
+    if (table->GetScreenBufferPropertiesQNX == nullptr) { table->GetScreenBufferPropertiesQNX = (PFN_vkGetScreenBufferPropertiesQNX)StubGetScreenBufferPropertiesQNX; }
+#endif // VK_USE_PLATFORM_SCREEN_QNX
 }
 
 

--- a/loader/generated-vksc/vk_dispatch_table_helper.h
+++ b/loader/generated-vksc/vk_dispatch_table_helper.h
@@ -7,6 +7,7 @@
  * Copyright (c) 2015-2017 Valve Corporation
  * Copyright (c) 2015-2017 LunarG, Inc.
  * Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2023-2023 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,25 +50,27 @@ static VKAPI_ATTR VkResult VKAPI_CALL StubAcquireProfilingLockKHR(VkDevice devic
 static VKAPI_ATTR void VKAPI_CALL StubReleaseProfilingLockKHR(VkDevice device) {  };
 static VKAPI_ATTR void VKAPI_CALL StubCmdSetFragmentShadingRateKHR(VkCommandBuffer           commandBuffer, const VkExtent2D*                           pFragmentSize, const VkFragmentShadingRateCombinerOpKHR    combinerOps[2]) {  };
 static VKAPI_ATTR void VKAPI_CALL StubCmdRefreshObjectsKHR(VkCommandBuffer commandBuffer, const VkRefreshObjectListKHR* pRefreshObjects) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdSetEvent2KHR(VkCommandBuffer                   commandBuffer, VkEvent                                             event, const VkDependencyInfoKHR*                          pDependencyInfo) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdResetEvent2KHR(VkCommandBuffer                   commandBuffer, VkEvent                                             event, VkPipelineStageFlags2KHR            stageMask) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdWaitEvents2KHR(VkCommandBuffer                   commandBuffer, uint32_t                                            eventCount, const VkEvent*                     pEvents, const VkDependencyInfoKHR*         pDependencyInfos) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdPipelineBarrier2KHR(VkCommandBuffer                   commandBuffer, const VkDependencyInfoKHR*                                pDependencyInfo) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdWriteTimestamp2KHR(VkCommandBuffer                   commandBuffer, VkPipelineStageFlags2KHR            stage, VkQueryPool                                         queryPool, uint32_t                                            query) {  };
-static VKAPI_ATTR VkResult VKAPI_CALL StubQueueSubmit2KHR(VkQueue                           queue, uint32_t                            submitCount, const VkSubmitInfo2KHR*           pSubmits, VkFence           fence) { return VK_SUCCESS; };
-static VKAPI_ATTR void VKAPI_CALL StubCmdWriteBufferMarker2AMD(VkCommandBuffer                   commandBuffer, VkPipelineStageFlags2KHR            stage, VkBuffer                                            dstBuffer, VkDeviceSize                                        dstOffset, uint32_t                                            marker) {  };
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetEvent2KHR(VkCommandBuffer                   commandBuffer, VkEvent                                             event, const VkDependencyInfo*                             pDependencyInfo) {  };
+static VKAPI_ATTR void VKAPI_CALL StubCmdResetEvent2KHR(VkCommandBuffer                   commandBuffer, VkEvent                                             event, VkPipelineStageFlags2               stageMask) {  };
+static VKAPI_ATTR void VKAPI_CALL StubCmdWaitEvents2KHR(VkCommandBuffer                   commandBuffer, uint32_t                                            eventCount, const VkEvent*                     pEvents, const VkDependencyInfo*            pDependencyInfos) {  };
+static VKAPI_ATTR void VKAPI_CALL StubCmdPipelineBarrier2KHR(VkCommandBuffer                   commandBuffer, const VkDependencyInfo*                             pDependencyInfo) {  };
+static VKAPI_ATTR void VKAPI_CALL StubCmdWriteTimestamp2KHR(VkCommandBuffer                   commandBuffer, VkPipelineStageFlags2               stage, VkQueryPool                                         queryPool, uint32_t                                            query) {  };
+static VKAPI_ATTR VkResult VKAPI_CALL StubQueueSubmit2KHR(VkQueue                           queue, uint32_t                            submitCount, const VkSubmitInfo2*              pSubmits, VkFence           fence) { return VK_SUCCESS; };
+static VKAPI_ATTR void VKAPI_CALL StubCmdWriteBufferMarker2AMD(VkCommandBuffer                   commandBuffer, VkPipelineStageFlags2               stage, VkBuffer                                            dstBuffer, VkDeviceSize                                        dstOffset, uint32_t                                            marker) {  };
 static VKAPI_ATTR void VKAPI_CALL StubGetQueueCheckpointData2NV(VkQueue queue, uint32_t* pCheckpointDataCount, VkCheckpointData2NV* pCheckpointData) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdCopyBuffer2KHR(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2KHR* pCopyBufferInfo) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdCopyImage2KHR(VkCommandBuffer commandBuffer, const VkCopyImageInfo2KHR* pCopyImageInfo) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdCopyBufferToImage2KHR(VkCommandBuffer commandBuffer, const VkCopyBufferToImageInfo2KHR* pCopyBufferToImageInfo) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdCopyImageToBuffer2KHR(VkCommandBuffer commandBuffer, const VkCopyImageToBufferInfo2KHR* pCopyImageToBufferInfo) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdBlitImage2KHR(VkCommandBuffer commandBuffer, const VkBlitImageInfo2KHR* pBlitImageInfo) {  };
-static VKAPI_ATTR void VKAPI_CALL StubCmdResolveImage2KHR(VkCommandBuffer commandBuffer, const VkResolveImageInfo2KHR* pResolveImageInfo) {  };
+static VKAPI_ATTR void VKAPI_CALL StubCmdCopyBuffer2KHR(VkCommandBuffer commandBuffer, const VkCopyBufferInfo2* pCopyBufferInfo) {  };
+static VKAPI_ATTR void VKAPI_CALL StubCmdCopyImage2KHR(VkCommandBuffer commandBuffer, const VkCopyImageInfo2* pCopyImageInfo) {  };
+static VKAPI_ATTR void VKAPI_CALL StubCmdCopyBufferToImage2KHR(VkCommandBuffer commandBuffer, const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo) {  };
+static VKAPI_ATTR void VKAPI_CALL StubCmdCopyImageToBuffer2KHR(VkCommandBuffer commandBuffer, const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo) {  };
+static VKAPI_ATTR void VKAPI_CALL StubCmdBlitImage2KHR(VkCommandBuffer commandBuffer, const VkBlitImageInfo2* pBlitImageInfo) {  };
+static VKAPI_ATTR void VKAPI_CALL StubCmdResolveImage2KHR(VkCommandBuffer commandBuffer, const VkResolveImageInfo2* pResolveImageInfo) {  };
 static VKAPI_ATTR VkResult VKAPI_CALL StubDisplayPowerControlEXT(VkDevice device, VkDisplayKHR display, const VkDisplayPowerInfoEXT* pDisplayPowerInfo) { return VK_SUCCESS; };
 static VKAPI_ATTR VkResult VKAPI_CALL StubRegisterDeviceEventEXT(VkDevice device, const VkDeviceEventInfoEXT* pDeviceEventInfo, const VkAllocationCallbacks* pAllocator, VkFence* pFence) { return VK_SUCCESS; };
 static VKAPI_ATTR VkResult VKAPI_CALL StubRegisterDisplayEventEXT(VkDevice device, VkDisplayKHR display, const VkDisplayEventInfoEXT* pDisplayEventInfo, const VkAllocationCallbacks* pAllocator, VkFence* pFence) { return VK_SUCCESS; };
 static VKAPI_ATTR VkResult VKAPI_CALL StubGetSwapchainCounterEXT(VkDevice device, VkSwapchainKHR swapchain, VkSurfaceCounterFlagBitsEXT counter, uint64_t* pCounterValue) { return VK_SUCCESS; };
 static VKAPI_ATTR void VKAPI_CALL StubCmdSetDiscardRectangleEXT(VkCommandBuffer commandBuffer, uint32_t firstDiscardRectangle, uint32_t discardRectangleCount, const VkRect2D* pDiscardRectangles) {  };
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetDiscardRectangleEnableEXT(VkCommandBuffer commandBuffer, VkBool32 discardRectangleEnable) {  };
+static VKAPI_ATTR void VKAPI_CALL StubCmdSetDiscardRectangleModeEXT(VkCommandBuffer commandBuffer, VkDiscardRectangleModeEXT discardRectangleMode) {  };
 static VKAPI_ATTR void VKAPI_CALL StubSetHdrMetadataEXT(VkDevice device, uint32_t swapchainCount, const VkSwapchainKHR* pSwapchains, const VkHdrMetadataEXT* pMetadata) {  };
 static VKAPI_ATTR void VKAPI_CALL StubCmdSetSampleLocationsEXT(VkCommandBuffer commandBuffer, const VkSampleLocationsInfoEXT* pSampleLocationsInfo) {  };
 static VKAPI_ATTR VkResult VKAPI_CALL StubGetImageDrmFormatModifierPropertiesEXT(VkDevice device, VkImage image, VkImageDrmFormatModifierPropertiesEXT* pProperties) { return VK_SUCCESS; };
@@ -336,6 +339,10 @@ static inline void layer_init_device_dispatch_table(VkDevice device, VkLayerDisp
     if (table->GetSwapchainCounterEXT == nullptr) { table->GetSwapchainCounterEXT = (PFN_vkGetSwapchainCounterEXT)StubGetSwapchainCounterEXT; }
     table->CmdSetDiscardRectangleEXT = (PFN_vkCmdSetDiscardRectangleEXT) gpa(device, "vkCmdSetDiscardRectangleEXT");
     if (table->CmdSetDiscardRectangleEXT == nullptr) { table->CmdSetDiscardRectangleEXT = (PFN_vkCmdSetDiscardRectangleEXT)StubCmdSetDiscardRectangleEXT; }
+    table->CmdSetDiscardRectangleEnableEXT = (PFN_vkCmdSetDiscardRectangleEnableEXT) gpa(device, "vkCmdSetDiscardRectangleEnableEXT");
+    if (table->CmdSetDiscardRectangleEnableEXT == nullptr) { table->CmdSetDiscardRectangleEnableEXT = (PFN_vkCmdSetDiscardRectangleEnableEXT)StubCmdSetDiscardRectangleEnableEXT; }
+    table->CmdSetDiscardRectangleModeEXT = (PFN_vkCmdSetDiscardRectangleModeEXT) gpa(device, "vkCmdSetDiscardRectangleModeEXT");
+    if (table->CmdSetDiscardRectangleModeEXT == nullptr) { table->CmdSetDiscardRectangleModeEXT = (PFN_vkCmdSetDiscardRectangleModeEXT)StubCmdSetDiscardRectangleModeEXT; }
     table->SetHdrMetadataEXT = (PFN_vkSetHdrMetadataEXT) gpa(device, "vkSetHdrMetadataEXT");
     if (table->SetHdrMetadataEXT == nullptr) { table->SetHdrMetadataEXT = (PFN_vkSetHdrMetadataEXT)StubSetHdrMetadataEXT; }
     table->SetDebugUtilsObjectNameEXT = (PFN_vkSetDebugUtilsObjectNameEXT) gpa(device, "vkSetDebugUtilsObjectNameEXT");

--- a/loader/generated-vksc/vk_layer_dispatch_table.h
+++ b/loader/generated-vksc/vk_layer_dispatch_table.h
@@ -32,7 +32,7 @@ typedef struct VkLayerInstanceDispatchTable_ {
     // Manually add in GetPhysicalDeviceProcAddr entry
     PFN_GetPhysicalDeviceProcAddr GetPhysicalDeviceProcAddr;
 
-    // ---- Core 1_0 commands
+    // ---- Core SC 1_0 commands
     PFN_vkCreateInstance CreateInstance;
     PFN_vkDestroyInstance DestroyInstance;
     PFN_vkEnumeratePhysicalDevices EnumeratePhysicalDevices;
@@ -48,8 +48,6 @@ typedef struct VkLayerInstanceDispatchTable_ {
     PFN_vkEnumerateDeviceExtensionProperties EnumerateDeviceExtensionProperties;
     PFN_vkEnumerateInstanceLayerProperties EnumerateInstanceLayerProperties;
     PFN_vkEnumerateDeviceLayerProperties EnumerateDeviceLayerProperties;
-
-    // ---- Core 1_1 commands
     PFN_vkEnumerateInstanceVersion EnumerateInstanceVersion;
     PFN_vkEnumeratePhysicalDeviceGroups EnumeratePhysicalDeviceGroups;
     PFN_vkGetPhysicalDeviceFeatures2 GetPhysicalDeviceFeatures2;
@@ -138,7 +136,7 @@ typedef struct VkLayerInstanceDispatchTable_ {
 // Device function pointer dispatch table
 typedef struct VkLayerDispatchTable_ {
 
-    // ---- Core 1_0 commands
+    // ---- Core SC 1_0 commands
     PFN_vkGetDeviceProcAddr GetDeviceProcAddr;
     PFN_vkDestroyDevice DestroyDevice;
     PFN_vkGetDeviceQueue GetDeviceQueue;
@@ -250,8 +248,6 @@ typedef struct VkLayerDispatchTable_ {
     PFN_vkCmdNextSubpass CmdNextSubpass;
     PFN_vkCmdEndRenderPass CmdEndRenderPass;
     PFN_vkCmdExecuteCommands CmdExecuteCommands;
-
-    // ---- Core 1_1 commands
     PFN_vkBindBufferMemory2 BindBufferMemory2;
     PFN_vkBindImageMemory2 BindImageMemory2;
     PFN_vkGetDeviceGroupPeerMemoryFeatures GetDeviceGroupPeerMemoryFeatures;
@@ -263,8 +259,6 @@ typedef struct VkLayerDispatchTable_ {
     PFN_vkCreateSamplerYcbcrConversion CreateSamplerYcbcrConversion;
     PFN_vkDestroySamplerYcbcrConversion DestroySamplerYcbcrConversion;
     PFN_vkGetDescriptorSetLayoutSupport GetDescriptorSetLayoutSupport;
-
-    // ---- Core 1_2 commands
     PFN_vkCmdDrawIndirectCount CmdDrawIndirectCount;
     PFN_vkCmdDrawIndexedIndirectCount CmdDrawIndexedIndirectCount;
     PFN_vkCreateRenderPass2 CreateRenderPass2;
@@ -278,8 +272,6 @@ typedef struct VkLayerDispatchTable_ {
     PFN_vkGetBufferDeviceAddress GetBufferDeviceAddress;
     PFN_vkGetBufferOpaqueCaptureAddress GetBufferOpaqueCaptureAddress;
     PFN_vkGetDeviceMemoryOpaqueCaptureAddress GetDeviceMemoryOpaqueCaptureAddress;
-
-    // ---- Core SC 1_0 commands
     PFN_vkGetCommandPoolMemoryConsumption GetCommandPoolMemoryConsumption;
     PFN_vkGetFaultData GetFaultData;
 
@@ -346,6 +338,8 @@ typedef struct VkLayerDispatchTable_ {
 
     // ---- VK_EXT_discard_rectangles extension commands
     PFN_vkCmdSetDiscardRectangleEXT CmdSetDiscardRectangleEXT;
+    PFN_vkCmdSetDiscardRectangleEnableEXT CmdSetDiscardRectangleEnableEXT;
+    PFN_vkCmdSetDiscardRectangleModeEXT CmdSetDiscardRectangleModeEXT;
 
     // ---- VK_EXT_hdr_metadata extension commands
     PFN_vkSetHdrMetadataEXT SetHdrMetadataEXT;

--- a/loader/generated-vksc/vk_layer_dispatch_table.h
+++ b/loader/generated-vksc/vk_layer_dispatch_table.h
@@ -425,6 +425,11 @@ typedef struct VkLayerDispatchTable_ {
 #ifdef VK_USE_PLATFORM_SCI
     PFN_vkCreateSemaphoreSciSyncPoolNV CreateSemaphoreSciSyncPoolNV;
 #endif // VK_USE_PLATFORM_SCI
+
+    // ---- VK_QNX_external_memory_screen_buffer extension commands
+#ifdef VK_USE_PLATFORM_SCREEN_QNX
+    PFN_vkGetScreenBufferPropertiesQNX GetScreenBufferPropertiesQNX;
+#endif // VK_USE_PLATFORM_SCREEN_QNX
 } VkLayerDispatchTable;
 
 

--- a/loader/generated-vksc/vk_loader_extensions.c
+++ b/loader/generated-vksc/vk_loader_extensions.c
@@ -478,6 +478,11 @@ VKAPI_ATTR void VKAPI_CALL loader_init_device_extension_dispatch_table(struct lo
 #ifdef VK_USE_PLATFORM_SCI
     table->CreateSemaphoreSciSyncPoolNV = (PFN_vkCreateSemaphoreSciSyncPoolNV)gdpa(dev, "vkCreateSemaphoreSciSyncPoolNV");
 #endif // VK_USE_PLATFORM_SCI
+
+    // ---- VK_QNX_external_memory_screen_buffer extension commands
+#ifdef VK_USE_PLATFORM_SCREEN_QNX
+    table->GetScreenBufferPropertiesQNX = (PFN_vkGetScreenBufferPropertiesQNX)gdpa(dev, "vkGetScreenBufferPropertiesQNX");
+#endif // VK_USE_PLATFORM_SCREEN_QNX
 }
 
 // Init Instance function pointer dispatch table with core commands
@@ -880,6 +885,11 @@ VKAPI_ATTR void* VKAPI_CALL loader_lookup_device_dispatch_table(const VkLayerDis
 #ifdef VK_USE_PLATFORM_SCI
     if (!strcmp(name, "CreateSemaphoreSciSyncPoolNV")) return (void *)table->CreateSemaphoreSciSyncPoolNV;
 #endif // VK_USE_PLATFORM_SCI
+
+    // ---- VK_QNX_external_memory_screen_buffer extension commands
+#ifdef VK_USE_PLATFORM_SCREEN_QNX
+    if (!strcmp(name, "GetScreenBufferPropertiesQNX")) return (void *)table->GetScreenBufferPropertiesQNX;
+#endif // VK_USE_PLATFORM_SCREEN_QNX
 
     return NULL;
 }
@@ -2022,6 +2032,19 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateSemaphoreSciSyncPoolNV(
 }
 
 #endif // VK_USE_PLATFORM_SCI
+
+// ---- VK_QNX_external_memory_screen_buffer extension trampoline/terminators
+
+#ifdef VK_USE_PLATFORM_SCREEN_QNX
+VKAPI_ATTR VkResult VKAPI_CALL GetScreenBufferPropertiesQNX(
+    VkDevice                                    device,
+    const struct _screen_buffer*                buffer,
+    VkScreenBufferPropertiesQNX*                pProperties) {
+    const VkLayerDispatchTable *disp = loader_get_dispatch(device);
+    return disp->GetScreenBufferPropertiesQNX(device, buffer, pProperties);
+}
+
+#endif // VK_USE_PLATFORM_SCREEN_QNX
 // GPA helpers for extensions
 bool extension_instance_gpa(struct loader_instance *ptr_instance, const char *name, void **addr) {
     *addr = NULL;
@@ -2458,6 +2481,14 @@ bool extension_instance_gpa(struct loader_instance *ptr_instance, const char *na
         return true;
     }
 #endif // VK_USE_PLATFORM_SCI
+
+    // ---- VK_QNX_external_memory_screen_buffer extension commands
+#ifdef VK_USE_PLATFORM_SCREEN_QNX
+    if (!strcmp("vkGetScreenBufferPropertiesQNX", name)) {
+        *addr = (void *)GetScreenBufferPropertiesQNX;
+        return true;
+    }
+#endif // VK_USE_PLATFORM_SCREEN_QNX
     return false;
 }
 

--- a/loader/generated-vksc/vk_loader_extensions.c
+++ b/loader/generated-vksc/vk_loader_extensions.c
@@ -61,7 +61,7 @@ VKAPI_ATTR bool VKAPI_CALL loader_icd_init_entries(struct loader_icd_term *icd_t
     } while (0)
 
 
-    // ---- Core 1_0
+    // ---- Core SC 1_0
     LOOKUP_GIPA(DestroyInstance, true);
     LOOKUP_GIPA(EnumeratePhysicalDevices, true);
     LOOKUP_GIPA(GetPhysicalDeviceFeatures, true);
@@ -73,18 +73,16 @@ VKAPI_ATTR bool VKAPI_CALL loader_icd_init_entries(struct loader_icd_term *icd_t
     LOOKUP_GIPA(GetDeviceProcAddr, true);
     LOOKUP_GIPA(CreateDevice, true);
     LOOKUP_GIPA(EnumerateDeviceExtensionProperties, true);
-
-    // ---- Core 1_1
-    LOOKUP_GIPA(EnumeratePhysicalDeviceGroups, false);
-    LOOKUP_GIPA(GetPhysicalDeviceFeatures2, false);
-    LOOKUP_GIPA(GetPhysicalDeviceProperties2, false);
-    LOOKUP_GIPA(GetPhysicalDeviceFormatProperties2, false);
-    LOOKUP_GIPA(GetPhysicalDeviceImageFormatProperties2, false);
-    LOOKUP_GIPA(GetPhysicalDeviceQueueFamilyProperties2, false);
-    LOOKUP_GIPA(GetPhysicalDeviceMemoryProperties2, false);
-    LOOKUP_GIPA(GetPhysicalDeviceExternalBufferProperties, false);
-    LOOKUP_GIPA(GetPhysicalDeviceExternalFenceProperties, false);
-    LOOKUP_GIPA(GetPhysicalDeviceExternalSemaphoreProperties, false);
+    LOOKUP_GIPA(EnumeratePhysicalDeviceGroups, true);
+    LOOKUP_GIPA(GetPhysicalDeviceFeatures2, true);
+    LOOKUP_GIPA(GetPhysicalDeviceProperties2, true);
+    LOOKUP_GIPA(GetPhysicalDeviceFormatProperties2, true);
+    LOOKUP_GIPA(GetPhysicalDeviceImageFormatProperties2, true);
+    LOOKUP_GIPA(GetPhysicalDeviceQueueFamilyProperties2, true);
+    LOOKUP_GIPA(GetPhysicalDeviceMemoryProperties2, true);
+    LOOKUP_GIPA(GetPhysicalDeviceExternalBufferProperties, true);
+    LOOKUP_GIPA(GetPhysicalDeviceExternalFenceProperties, true);
+    LOOKUP_GIPA(GetPhysicalDeviceExternalSemaphoreProperties, true);
 
     // ---- VK_KHR_surface extension commands
     LOOKUP_GIPA(DestroySurfaceKHR, false);
@@ -182,7 +180,7 @@ VKAPI_ATTR void VKAPI_CALL loader_init_device_dispatch_table(struct loader_dev_d
     VkLayerDispatchTable *table = &dev_table->core_dispatch;
     for (uint32_t i = 0; i < MAX_NUM_UNKNOWN_EXTS; i++) dev_table->ext_dispatch.dev_ext[i] = (PFN_vkDevExt)vkDevExtError;
 
-    // ---- Core 1_0 commands
+    // ---- Core SC 1_0 commands
     table->GetDeviceProcAddr = gpa;
     table->DestroyDevice = (PFN_vkDestroyDevice)gpa(dev, "vkDestroyDevice");
     table->GetDeviceQueue = (PFN_vkGetDeviceQueue)gpa(dev, "vkGetDeviceQueue");
@@ -294,8 +292,6 @@ VKAPI_ATTR void VKAPI_CALL loader_init_device_dispatch_table(struct loader_dev_d
     table->CmdNextSubpass = (PFN_vkCmdNextSubpass)gpa(dev, "vkCmdNextSubpass");
     table->CmdEndRenderPass = (PFN_vkCmdEndRenderPass)gpa(dev, "vkCmdEndRenderPass");
     table->CmdExecuteCommands = (PFN_vkCmdExecuteCommands)gpa(dev, "vkCmdExecuteCommands");
-
-    // ---- Core 1_1 commands
     table->BindBufferMemory2 = (PFN_vkBindBufferMemory2)gpa(dev, "vkBindBufferMemory2");
     table->BindImageMemory2 = (PFN_vkBindImageMemory2)gpa(dev, "vkBindImageMemory2");
     table->GetDeviceGroupPeerMemoryFeatures = (PFN_vkGetDeviceGroupPeerMemoryFeatures)gpa(dev, "vkGetDeviceGroupPeerMemoryFeatures");
@@ -307,8 +303,6 @@ VKAPI_ATTR void VKAPI_CALL loader_init_device_dispatch_table(struct loader_dev_d
     table->CreateSamplerYcbcrConversion = (PFN_vkCreateSamplerYcbcrConversion)gpa(dev, "vkCreateSamplerYcbcrConversion");
     table->DestroySamplerYcbcrConversion = (PFN_vkDestroySamplerYcbcrConversion)gpa(dev, "vkDestroySamplerYcbcrConversion");
     table->GetDescriptorSetLayoutSupport = (PFN_vkGetDescriptorSetLayoutSupport)gpa(dev, "vkGetDescriptorSetLayoutSupport");
-
-    // ---- Core 1_2 commands
     table->CmdDrawIndirectCount = (PFN_vkCmdDrawIndirectCount)gpa(dev, "vkCmdDrawIndirectCount");
     table->CmdDrawIndexedIndirectCount = (PFN_vkCmdDrawIndexedIndirectCount)gpa(dev, "vkCmdDrawIndexedIndirectCount");
     table->CreateRenderPass2 = (PFN_vkCreateRenderPass2)gpa(dev, "vkCreateRenderPass2");
@@ -322,8 +316,6 @@ VKAPI_ATTR void VKAPI_CALL loader_init_device_dispatch_table(struct loader_dev_d
     table->GetBufferDeviceAddress = (PFN_vkGetBufferDeviceAddress)gpa(dev, "vkGetBufferDeviceAddress");
     table->GetBufferOpaqueCaptureAddress = (PFN_vkGetBufferOpaqueCaptureAddress)gpa(dev, "vkGetBufferOpaqueCaptureAddress");
     table->GetDeviceMemoryOpaqueCaptureAddress = (PFN_vkGetDeviceMemoryOpaqueCaptureAddress)gpa(dev, "vkGetDeviceMemoryOpaqueCaptureAddress");
-
-    // ---- Core SC 1_0 commands
     table->GetCommandPoolMemoryConsumption = (PFN_vkGetCommandPoolMemoryConsumption)gpa(dev, "vkGetCommandPoolMemoryConsumption");
     table->GetFaultData = (PFN_vkGetFaultData)gpa(dev, "vkGetFaultData");
 }
@@ -399,6 +391,8 @@ VKAPI_ATTR void VKAPI_CALL loader_init_device_extension_dispatch_table(struct lo
 
     // ---- VK_EXT_discard_rectangles extension commands
     table->CmdSetDiscardRectangleEXT = (PFN_vkCmdSetDiscardRectangleEXT)gdpa(dev, "vkCmdSetDiscardRectangleEXT");
+    table->CmdSetDiscardRectangleEnableEXT = (PFN_vkCmdSetDiscardRectangleEnableEXT)gdpa(dev, "vkCmdSetDiscardRectangleEnableEXT");
+    table->CmdSetDiscardRectangleModeEXT = (PFN_vkCmdSetDiscardRectangleModeEXT)gdpa(dev, "vkCmdSetDiscardRectangleModeEXT");
 
     // ---- VK_EXT_hdr_metadata extension commands
     table->SetHdrMetadataEXT = (PFN_vkSetHdrMetadataEXT)gdpa(dev, "vkSetHdrMetadataEXT");
@@ -490,7 +484,7 @@ VKAPI_ATTR void VKAPI_CALL loader_init_device_extension_dispatch_table(struct lo
 VKAPI_ATTR void VKAPI_CALL loader_init_instance_core_dispatch_table(VkLayerInstanceDispatchTable *table, PFN_vkGetInstanceProcAddr gpa,
                                                                     VkInstance inst) {
 
-    // ---- Core 1_0 commands
+    // ---- Core SC 1_0 commands
     table->DestroyInstance = (PFN_vkDestroyInstance)gpa(inst, "vkDestroyInstance");
     table->EnumeratePhysicalDevices = (PFN_vkEnumeratePhysicalDevices)gpa(inst, "vkEnumeratePhysicalDevices");
     table->GetPhysicalDeviceFeatures = (PFN_vkGetPhysicalDeviceFeatures)gpa(inst, "vkGetPhysicalDeviceFeatures");
@@ -502,8 +496,6 @@ VKAPI_ATTR void VKAPI_CALL loader_init_instance_core_dispatch_table(VkLayerInsta
     table->GetInstanceProcAddr = gpa;
     table->EnumerateDeviceExtensionProperties = (PFN_vkEnumerateDeviceExtensionProperties)gpa(inst, "vkEnumerateDeviceExtensionProperties");
     table->EnumerateDeviceLayerProperties = (PFN_vkEnumerateDeviceLayerProperties)gpa(inst, "vkEnumerateDeviceLayerProperties");
-
-    // ---- Core 1_1 commands
     table->EnumeratePhysicalDeviceGroups = (PFN_vkEnumeratePhysicalDeviceGroups)gpa(inst, "vkEnumeratePhysicalDeviceGroups");
     table->GetPhysicalDeviceFeatures2 = (PFN_vkGetPhysicalDeviceFeatures2)gpa(inst, "vkGetPhysicalDeviceFeatures2");
     table->GetPhysicalDeviceProperties2 = (PFN_vkGetPhysicalDeviceProperties2)gpa(inst, "vkGetPhysicalDeviceProperties2");
@@ -599,7 +591,7 @@ VKAPI_ATTR void* VKAPI_CALL loader_lookup_device_dispatch_table(const VkLayerDis
 
     name += 2;
 
-    // ---- Core 1_0 commands
+    // ---- Core SC 1_0 commands
     if (!strcmp(name, "GetDeviceProcAddr")) return (void *)table->GetDeviceProcAddr;
     if (!strcmp(name, "DestroyDevice")) return (void *)table->DestroyDevice;
     if (!strcmp(name, "GetDeviceQueue")) return (void *)table->GetDeviceQueue;
@@ -711,8 +703,6 @@ VKAPI_ATTR void* VKAPI_CALL loader_lookup_device_dispatch_table(const VkLayerDis
     if (!strcmp(name, "CmdNextSubpass")) return (void *)table->CmdNextSubpass;
     if (!strcmp(name, "CmdEndRenderPass")) return (void *)table->CmdEndRenderPass;
     if (!strcmp(name, "CmdExecuteCommands")) return (void *)table->CmdExecuteCommands;
-
-    // ---- Core 1_1 commands
     if (!strcmp(name, "BindBufferMemory2")) return (void *)table->BindBufferMemory2;
     if (!strcmp(name, "BindImageMemory2")) return (void *)table->BindImageMemory2;
     if (!strcmp(name, "GetDeviceGroupPeerMemoryFeatures")) return (void *)table->GetDeviceGroupPeerMemoryFeatures;
@@ -724,8 +714,6 @@ VKAPI_ATTR void* VKAPI_CALL loader_lookup_device_dispatch_table(const VkLayerDis
     if (!strcmp(name, "CreateSamplerYcbcrConversion")) return (void *)table->CreateSamplerYcbcrConversion;
     if (!strcmp(name, "DestroySamplerYcbcrConversion")) return (void *)table->DestroySamplerYcbcrConversion;
     if (!strcmp(name, "GetDescriptorSetLayoutSupport")) return (void *)table->GetDescriptorSetLayoutSupport;
-
-    // ---- Core 1_2 commands
     if (!strcmp(name, "CmdDrawIndirectCount")) return (void *)table->CmdDrawIndirectCount;
     if (!strcmp(name, "CmdDrawIndexedIndirectCount")) return (void *)table->CmdDrawIndexedIndirectCount;
     if (!strcmp(name, "CreateRenderPass2")) return (void *)table->CreateRenderPass2;
@@ -739,8 +727,6 @@ VKAPI_ATTR void* VKAPI_CALL loader_lookup_device_dispatch_table(const VkLayerDis
     if (!strcmp(name, "GetBufferDeviceAddress")) return (void *)table->GetBufferDeviceAddress;
     if (!strcmp(name, "GetBufferOpaqueCaptureAddress")) return (void *)table->GetBufferOpaqueCaptureAddress;
     if (!strcmp(name, "GetDeviceMemoryOpaqueCaptureAddress")) return (void *)table->GetDeviceMemoryOpaqueCaptureAddress;
-
-    // ---- Core SC 1_0 commands
     if (!strcmp(name, "GetCommandPoolMemoryConsumption")) return (void *)table->GetCommandPoolMemoryConsumption;
     if (!strcmp(name, "GetFaultData")) return (void *)table->GetFaultData;
 
@@ -807,6 +793,8 @@ VKAPI_ATTR void* VKAPI_CALL loader_lookup_device_dispatch_table(const VkLayerDis
 
     // ---- VK_EXT_discard_rectangles extension commands
     if (!strcmp(name, "CmdSetDiscardRectangleEXT")) return (void *)table->CmdSetDiscardRectangleEXT;
+    if (!strcmp(name, "CmdSetDiscardRectangleEnableEXT")) return (void *)table->CmdSetDiscardRectangleEnableEXT;
+    if (!strcmp(name, "CmdSetDiscardRectangleModeEXT")) return (void *)table->CmdSetDiscardRectangleModeEXT;
 
     // ---- VK_EXT_hdr_metadata extension commands
     if (!strcmp(name, "SetHdrMetadataEXT")) return (void *)table->SetHdrMetadataEXT;
@@ -907,7 +895,7 @@ VKAPI_ATTR void* VKAPI_CALL loader_lookup_instance_dispatch_table(const VkLayerI
     *found_name = true;
     name += 2;
 
-    // ---- Core 1_0 commands
+    // ---- Core SC 1_0 commands
     if (!strcmp(name, "DestroyInstance")) return (void *)table->DestroyInstance;
     if (!strcmp(name, "EnumeratePhysicalDevices")) return (void *)table->EnumeratePhysicalDevices;
     if (!strcmp(name, "GetPhysicalDeviceFeatures")) return (void *)table->GetPhysicalDeviceFeatures;
@@ -919,8 +907,6 @@ VKAPI_ATTR void* VKAPI_CALL loader_lookup_instance_dispatch_table(const VkLayerI
     if (!strcmp(name, "GetInstanceProcAddr")) return (void *)table->GetInstanceProcAddr;
     if (!strcmp(name, "EnumerateDeviceExtensionProperties")) return (void *)table->EnumerateDeviceExtensionProperties;
     if (!strcmp(name, "EnumerateDeviceLayerProperties")) return (void *)table->EnumerateDeviceLayerProperties;
-
-    // ---- Core 1_1 commands
     if (!strcmp(name, "EnumeratePhysicalDeviceGroups")) return (void *)table->EnumeratePhysicalDeviceGroups;
     if (!strcmp(name, "GetPhysicalDeviceFeatures2")) return (void *)table->GetPhysicalDeviceFeatures2;
     if (!strcmp(name, "GetPhysicalDeviceProperties2")) return (void *)table->GetPhysicalDeviceProperties2;
@@ -1213,7 +1199,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_GetPhysicalDeviceRefreshableObjectType
 VKAPI_ATTR void VKAPI_CALL CmdSetEvent2KHR(
     VkCommandBuffer                             commandBuffer,
     VkEvent                                     event,
-    const VkDependencyInfoKHR*                  pDependencyInfo) {
+    const VkDependencyInfo*                     pDependencyInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     disp->CmdSetEvent2KHR(commandBuffer, event, pDependencyInfo);
 }
@@ -1221,7 +1207,7 @@ VKAPI_ATTR void VKAPI_CALL CmdSetEvent2KHR(
 VKAPI_ATTR void VKAPI_CALL CmdResetEvent2KHR(
     VkCommandBuffer                             commandBuffer,
     VkEvent                                     event,
-    VkPipelineStageFlags2KHR                    stageMask) {
+    VkPipelineStageFlags2                       stageMask) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     disp->CmdResetEvent2KHR(commandBuffer, event, stageMask);
 }
@@ -1230,21 +1216,21 @@ VKAPI_ATTR void VKAPI_CALL CmdWaitEvents2KHR(
     VkCommandBuffer                             commandBuffer,
     uint32_t                                    eventCount,
     const VkEvent*                              pEvents,
-    const VkDependencyInfoKHR*                  pDependencyInfos) {
+    const VkDependencyInfo*                     pDependencyInfos) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     disp->CmdWaitEvents2KHR(commandBuffer, eventCount, pEvents, pDependencyInfos);
 }
 
 VKAPI_ATTR void VKAPI_CALL CmdPipelineBarrier2KHR(
     VkCommandBuffer                             commandBuffer,
-    const VkDependencyInfoKHR*                  pDependencyInfo) {
+    const VkDependencyInfo*                     pDependencyInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     disp->CmdPipelineBarrier2KHR(commandBuffer, pDependencyInfo);
 }
 
 VKAPI_ATTR void VKAPI_CALL CmdWriteTimestamp2KHR(
     VkCommandBuffer                             commandBuffer,
-    VkPipelineStageFlags2KHR                    stage,
+    VkPipelineStageFlags2                       stage,
     VkQueryPool                                 queryPool,
     uint32_t                                    query) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
@@ -1254,7 +1240,7 @@ VKAPI_ATTR void VKAPI_CALL CmdWriteTimestamp2KHR(
 VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit2KHR(
     VkQueue                                     queue,
     uint32_t                                    submitCount,
-    const VkSubmitInfo2KHR*                     pSubmits,
+    const VkSubmitInfo2*                        pSubmits,
     VkFence                                     fence) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(queue);
     return disp->QueueSubmit2KHR(queue, submitCount, pSubmits, fence);
@@ -1262,7 +1248,7 @@ VKAPI_ATTR VkResult VKAPI_CALL QueueSubmit2KHR(
 
 VKAPI_ATTR void VKAPI_CALL CmdWriteBufferMarker2AMD(
     VkCommandBuffer                             commandBuffer,
-    VkPipelineStageFlags2KHR                    stage,
+    VkPipelineStageFlags2                       stage,
     VkBuffer                                    dstBuffer,
     VkDeviceSize                                dstOffset,
     uint32_t                                    marker) {
@@ -1283,42 +1269,42 @@ VKAPI_ATTR void VKAPI_CALL GetQueueCheckpointData2NV(
 
 VKAPI_ATTR void VKAPI_CALL CmdCopyBuffer2KHR(
     VkCommandBuffer                             commandBuffer,
-    const VkCopyBufferInfo2KHR*                 pCopyBufferInfo) {
+    const VkCopyBufferInfo2*                    pCopyBufferInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     disp->CmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo);
 }
 
 VKAPI_ATTR void VKAPI_CALL CmdCopyImage2KHR(
     VkCommandBuffer                             commandBuffer,
-    const VkCopyImageInfo2KHR*                  pCopyImageInfo) {
+    const VkCopyImageInfo2*                     pCopyImageInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     disp->CmdCopyImage2KHR(commandBuffer, pCopyImageInfo);
 }
 
 VKAPI_ATTR void VKAPI_CALL CmdCopyBufferToImage2KHR(
     VkCommandBuffer                             commandBuffer,
-    const VkCopyBufferToImageInfo2KHR*          pCopyBufferToImageInfo) {
+    const VkCopyBufferToImageInfo2*             pCopyBufferToImageInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     disp->CmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo);
 }
 
 VKAPI_ATTR void VKAPI_CALL CmdCopyImageToBuffer2KHR(
     VkCommandBuffer                             commandBuffer,
-    const VkCopyImageToBufferInfo2KHR*          pCopyImageToBufferInfo) {
+    const VkCopyImageToBufferInfo2*             pCopyImageToBufferInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     disp->CmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo);
 }
 
 VKAPI_ATTR void VKAPI_CALL CmdBlitImage2KHR(
     VkCommandBuffer                             commandBuffer,
-    const VkBlitImageInfo2KHR*                  pBlitImageInfo) {
+    const VkBlitImageInfo2*                     pBlitImageInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     disp->CmdBlitImage2KHR(commandBuffer, pBlitImageInfo);
 }
 
 VKAPI_ATTR void VKAPI_CALL CmdResolveImage2KHR(
     VkCommandBuffer                             commandBuffer,
-    const VkResolveImageInfo2KHR*               pResolveImageInfo) {
+    const VkResolveImageInfo2*                  pResolveImageInfo) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     disp->CmdResolveImage2KHR(commandBuffer, pResolveImageInfo);
 }
@@ -1372,6 +1358,20 @@ VKAPI_ATTR void VKAPI_CALL CmdSetDiscardRectangleEXT(
     const VkRect2D*                             pDiscardRectangles) {
     const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
     disp->CmdSetDiscardRectangleEXT(commandBuffer, firstDiscardRectangle, discardRectangleCount, pDiscardRectangles);
+}
+
+VKAPI_ATTR void VKAPI_CALL CmdSetDiscardRectangleEnableEXT(
+    VkCommandBuffer                             commandBuffer,
+    VkBool32                                    discardRectangleEnable) {
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    disp->CmdSetDiscardRectangleEnableEXT(commandBuffer, discardRectangleEnable);
+}
+
+VKAPI_ATTR void VKAPI_CALL CmdSetDiscardRectangleModeEXT(
+    VkCommandBuffer                             commandBuffer,
+    VkDiscardRectangleModeEXT                   discardRectangleMode) {
+    const VkLayerDispatchTable *disp = loader_get_dispatch(commandBuffer);
+    disp->CmdSetDiscardRectangleModeEXT(commandBuffer, discardRectangleMode);
 }
 
 
@@ -2200,6 +2200,14 @@ bool extension_instance_gpa(struct loader_instance *ptr_instance, const char *na
         *addr = (void *)CmdSetDiscardRectangleEXT;
         return true;
     }
+    if (!strcmp("vkCmdSetDiscardRectangleEnableEXT", name)) {
+        *addr = (void *)CmdSetDiscardRectangleEnableEXT;
+        return true;
+    }
+    if (!strcmp("vkCmdSetDiscardRectangleModeEXT", name)) {
+        *addr = (void *)CmdSetDiscardRectangleModeEXT;
+        return true;
+    }
 
     // ---- VK_EXT_hdr_metadata extension commands
     if (!strcmp("vkSetHdrMetadataEXT", name)) {
@@ -2522,7 +2530,7 @@ PFN_vkVoidFunction get_extension_device_proc_terminator(struct loader_device *de
 // pointers to "terminator functions".
 const VkLayerInstanceDispatchTable instance_disp = {
 
-    // ---- Core 1_0 commands
+    // ---- Core SC 1_0 commands
     .DestroyInstance = terminator_DestroyInstance,
     .EnumeratePhysicalDevices = terminator_EnumeratePhysicalDevices,
     .GetPhysicalDeviceFeatures = terminator_GetPhysicalDeviceFeatures,
@@ -2534,8 +2542,6 @@ const VkLayerInstanceDispatchTable instance_disp = {
     .GetInstanceProcAddr = vkGetInstanceProcAddr,
     .EnumerateDeviceExtensionProperties = terminator_EnumerateDeviceExtensionProperties,
     .EnumerateDeviceLayerProperties = terminator_EnumerateDeviceLayerProperties,
-
-    // ---- Core 1_1 commands
     .EnumeratePhysicalDeviceGroups = terminator_EnumeratePhysicalDeviceGroups,
     .GetPhysicalDeviceFeatures2 = terminator_GetPhysicalDeviceFeatures2,
     .GetPhysicalDeviceProperties2 = terminator_GetPhysicalDeviceProperties2,

--- a/loader/generated-vksc/vk_loader_extensions.h
+++ b/loader/generated-vksc/vk_loader_extensions.h
@@ -191,7 +191,7 @@ VKAPI_ATTR void VKAPI_CALL terminator_GetPhysicalDeviceExternalSemaphoreProperti
 // ICD function pointer dispatch table
 struct loader_icd_term_dispatch {
 
-    // ---- Core 1_0 commands
+    // ---- Core SC 1_0 commands
     PFN_vkCreateInstance CreateInstance;
     PFN_vkDestroyInstance DestroyInstance;
     PFN_vkEnumeratePhysicalDevices EnumeratePhysicalDevices;
@@ -206,8 +206,6 @@ struct loader_icd_term_dispatch {
     PFN_vkEnumerateInstanceExtensionProperties EnumerateInstanceExtensionProperties;
     PFN_vkEnumerateDeviceExtensionProperties EnumerateDeviceExtensionProperties;
     PFN_vkEnumerateInstanceLayerProperties EnumerateInstanceLayerProperties;
-
-    // ---- Core 1_1 commands
     PFN_vkEnumerateInstanceVersion EnumerateInstanceVersion;
     PFN_vkEnumeratePhysicalDeviceGroups EnumeratePhysicalDeviceGroups;
     PFN_vkGetPhysicalDeviceFeatures2 GetPhysicalDeviceFeatures2;

--- a/loader/generated/vk_dispatch_table_helper.h
+++ b/loader/generated/vk_dispatch_table_helper.h
@@ -7,6 +7,7 @@
  * Copyright (c) 2015-2017 Valve Corporation
  * Copyright (c) 2015-2017 LunarG, Inc.
  * Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2023-2023 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/loader/vk_loader_platform.h
+++ b/loader/vk_loader_platform.h
@@ -4,6 +4,7 @@
  * Copyright (c) 2015-2021 Valve Corporation
  * Copyright (c) 2015-2021 LunarG, Inc.
  * Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * Copyright (c) 2023-2023 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +70,6 @@
 #endif  // defined(_WIN32)
 
 #include "vulkan/vk_platform.h"
-#include "vulkan/vk_sdk_platform.h"
 #ifdef VULKANSC
 #include <vulkan/vulkan_sc.h>
 #else
@@ -78,11 +78,14 @@
 #include <vulkan/vk_layer.h>
 #include <vulkan/vk_icd.h>
 
+#include "vksc_header_wa.h"
+
 #include "vk_loader_layer.h"
 #include "vk_layer_dispatch_table.h"
 #include "vk_loader_extensions.h"
 
-#ifdef VULKANSC
+// If not building with the combined headers, then need some compatibility #defines
+#ifndef VULKAN_H_
 #define VK_DEBUG_REPORT_INFORMATION_BIT_EXT VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT
 #define VK_DEBUG_REPORT_WARNING_BIT_EXT VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT
 #define VK_DEBUG_REPORT_ERROR_BIT_EXT VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT
@@ -101,13 +104,13 @@ typedef VkQueueFamilyProperties2 VkQueueFamilyProperties2KHR;
 typedef VkExternalMemoryProperties VkExternalMemoryPropertiesKHR;
 typedef VkPhysicalDeviceExternalSemaphoreInfo VkPhysicalDeviceExternalSemaphoreInfoKHR;
 
-
 // Other required macros
 #define VK_MAKE_VERSION(major, minor, patch) VK_MAKE_API_VERSION(VKSC_API_VARIANT, major, minor, patch)
 #define VK_VERSION_MAJOR(version) VK_API_VERSION_MAJOR(version)
 #define VK_VERSION_MINOR(version) VK_API_VERSION_MINOR(version)
 #define VK_VERSION_PATCH(version) VK_API_VERSION_PATCH(version)
-#endif // VULKANSC
+
+#endif // VULKAN_H_
 
 #if defined(__GNUC__) && __GNUC__ >= 4
 #define LOADER_EXPORT __attribute__((visibility("default")))

--- a/loader/vksc_header_wa.h
+++ b/loader/vksc_header_wa.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2023-2023 The Khronos Group Inc.
+ * Copyright (c) 2023-2023 RasterGrid Kft.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#ifdef VULKANSC
+#include <vulkan/vulkan_sc.h>
+#else
+#include <vulkan/vulkan.h>
+#endif // VULKANSC
+
+// Workaround for missing definitions from the 1.0.12 header otherwise present in the XML
+#if VK_HEADER_VERSION <= 12
+typedef void (VKAPI_PTR *PFN_vkCmdSetDiscardRectangleEnableEXT)(VkCommandBuffer commandBuffer, VkBool32 discardRectangleEnable);
+typedef void (VKAPI_PTR *PFN_vkCmdSetDiscardRectangleModeEXT)(VkCommandBuffer commandBuffer, VkDiscardRectangleModeEXT discardRectangleMode);
+
+typedef VkDependencyInfoKHR VkDependencyInfo;
+typedef VkPipelineStageFlags2KHR VkPipelineStageFlags2;
+typedef VkSubmitInfo2KHR VkSubmitInfo2;
+typedef VkCopyBufferInfo2KHR VkCopyBufferInfo2;
+typedef VkCopyImageInfo2KHR VkCopyImageInfo2;
+typedef VkCopyBufferToImageInfo2KHR VkCopyBufferToImageInfo2;
+typedef VkCopyImageToBufferInfo2KHR VkCopyImageToBufferInfo2;
+typedef VkBlitImageInfo2KHR VkBlitImageInfo2;
+typedef VkResolveImageInfo2KHR VkResolveImageInfo2;
+#endif

--- a/scripts/dispatch_table_helper_generator.py
+++ b/scripts/dispatch_table_helper_generator.py
@@ -5,6 +5,7 @@
 # Copyright (c) 2015-2017 LunarG, Inc.
 # Copyright (c) 2015-2017 Google Inc.
 # Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023-2023 RasterGrid Kft.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -112,6 +113,7 @@ class DispatchTableHelperOutputGenerator(OutputGenerator):
         copyright += ' * Copyright (c) 2015-2017 Valve Corporation\n'
         copyright += ' * Copyright (c) 2015-2017 LunarG, Inc.\n'
         copyright += ' * Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.\n'
+        copyright += ' * Copyright (c) 2023-2023 RasterGrid Kft.\n'
         copyright += ' *\n'
         copyright += ' * Licensed under the Apache License, Version 2.0 (the "License");\n'
         copyright += ' * you may not use this file except in compliance with the License.\n'
@@ -186,9 +188,24 @@ class DispatchTableHelperOutputGenerator(OutputGenerator):
         handle = self.registry.tree.find("types/type/[name='" + handle_type + "'][@category='handle']")
         if handle is None:
             return
+
+        feature = self.featureName
+        version_prefix = 'VK_VERSION'
+
+        if self.genOpts.apiname == 'vulkansc':
+            version_prefix = 'VKSC_VERSION'
+
+            if self.featureName in ['VK_VERSION_1_0', 'VK_VERSION_1_1', 'VK_VERSION_1_2']:
+                # Vulkan 1.0-1.2 is included in Vulkan SC 1.0
+                feature = 'VKSC_VERSION_1_0'
+
+            if "VK_VERSION" in feature:
+                # Do not handle commands in Vulkan versions not included in a Vulkan SC version
+                return
+
         if handle_type != 'VkInstance' and handle_type != 'VkPhysicalDevice' and name != 'vkGetInstanceProcAddr':
             self.device_dispatch_list.append((name, self.featureExtraProtect))
-            if "VK_VERSION" not in self.featureName and self.extension_type == 'device':
+            if version_prefix not in feature and self.extension_type == 'device':
                 self.device_extension_list.append(name)
                 # Build up stub function
                 decl = self.makeCDecls(cmdinfo.elem)[1]

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -4,6 +4,7 @@
 # Copyright (c) 2019 LunarG, Inc.
 # Copyright (c) 2019 Google Inc.
 # Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023-2023 RasterGrid Kft.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,7 +35,10 @@ verify_exclude = ['.clang-format']
 def main(argv):
     parser = argparse.ArgumentParser(description='Generate source code for this repository')
     parser.add_argument('registry', metavar='REGISTRY_PATH', help='path to the Vulkan-Headers registry directory')
-    parser.add_argument('--api', help='generate extensions for the api provided vulkan or vulkansc', default='vulkan')
+    parser.add_argument('--api',
+                        default='vulkan',
+                        choices=['vulkan', 'vulkansc'],
+                        help='Specify API name to generate')
     group = parser.add_mutually_exclusive_group()
     group.add_argument('-i', '--incremental', action='store_true', help='only update repo files that change')
     group.add_argument('-v', '--verify', action='store_true', help='verify repo files match generator output')
@@ -59,9 +63,9 @@ def main(argv):
         gen_filenames = vksc_filenames
 
     gen_cmds = [[common_codegen.repo_relative('scripts/loader_genvk.py'),
+                 '-api', args.api,
                  '-registry', os.path.abspath(os.path.join(args.registry,  'vk.xml')),
                  '-quiet',
-                 '-defaultExtensions', args.api,
                  filename] for filename in gen_filenames]
 
     repo_dir = common_codegen.repo_relative('loader/generated')

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -19,7 +19,7 @@
             "cmake_options": [
                 "-DVULKANSC=ON"
             ],
-            "commit": "fece0e8e98d139ebc6eed30b430ed31c1ece2233"
+            "commit": "e8febd2664a72d0e4d029585822ea3fa127f916e"
         },
         {
             "name": "googletest",

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -19,7 +19,7 @@
             "cmake_options": [
                 "-DVULKANSC=ON"
             ],
-            "commit": "sc_beta"
+            "commit": "fece0e8e98d139ebc6eed30b430ed31c1ece2233"
         },
         {
             "name": "googletest",

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -2,6 +2,7 @@
     "repos": [
         {
             "name": "Vulkan-Headers",
+            "api": "vulkan",
             "url": "https://github.com/KhronosGroup/Vulkan-Headers.git",
             "sub_dir": "Vulkan-Headers",
             "build_dir": "Vulkan-Headers/build",
@@ -9,15 +10,16 @@
             "commit": "v1.2.198"
         },
         {
-            "name" : "VulkanSC-Headers",
-            "url" : "https://github.com/KhronosGroup/Vulkan-Headers.git",
-            "sub_dir" : "VulkanSC-Headers",
-            "build_dir" : "VulkanSC-Headers/build",
-            "install_dir" : "VulkanSC-Headers/build/install",
-            "cmake_options" : [
-              "-DVULKANSC=ON"
+            "name": "Vulkan-Headers",
+            "api": "vulkansc",
+            "url": "https://github.com/KhronosGroup/VulkanSC-Headers.git",
+            "sub_dir": "Vulkan-Headers",
+            "build_dir": "Vulkan-Headers/build",
+            "install_dir": "Vulkan-Headers/build/install",
+            "cmake_options": [
+                "-DVULKANSC=ON"
             ],
-            "commit" : "vksc1.0.12"
+            "commit": "sc_beta"
         },
         {
             "name": "googletest",
@@ -49,7 +51,6 @@
     ],
     "install_names": {
         "Vulkan-Headers": "VULKAN_HEADERS_INSTALL_DIR",
-        "VulkanSC-Headers" : "VULKAN_HEADERS_INSTALL_DIR",
         "googletest": "GOOGLETEST_INSTALL_DIR",
         "detours": "DETOURS_INSTALL_DIR"
     }

--- a/scripts/loader_genvk.py
+++ b/scripts/loader_genvk.py
@@ -2,6 +2,7 @@
 #
 # Copyright (c) 2013-2019 The Khronos Group Inc.
 # Copyright (c) 2021-2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright (c) 2023-2023 RasterGrid Kft.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -48,8 +49,14 @@ def makeGenOpts(args):
     global genOpts
     genOpts = {}
 
+    # API to generate sources for
+    apiname = args.api
+
     # Default class of extensions to include, or None
-    defaultExtensions = args.defaultExtensions
+    if args.defaultExtensions is not None:
+        defaultExtensions = args.defaultExtensions
+    else:
+        defaultExtensions = apiname
 
     # Additional extensions to include (list of extensions)
     extensions = args.extension
@@ -118,9 +125,6 @@ def makeGenOpts(args):
     # An API style conventions object
     conventions = VulkanConventions()
 
-    # Change this depending on which repository/spec we're building
-    defaultApiName = conventions.xml_api_name
-
     # Loader Generators
     # Options for dispatch table helper generator
     genOpts['vk_dispatch_table_helper.h'] = [
@@ -130,7 +134,7 @@ def makeGenOpts(args):
             filename          = 'vk_dispatch_table_helper.h',
             directory         = directory,
             genpath           = None,
-            apiname           = defaultApiName,
+            apiname           = apiname,
             profile           = None,
             versions          = featuresPat,
             emitversions      = featuresPat,
@@ -154,7 +158,7 @@ def makeGenOpts(args):
             filename          = 'vk_layer_dispatch_table.h',
             directory         = directory,
             genpath           = None,
-            apiname           = defaultApiName,
+            apiname           = apiname,
             profile           = None,
             versions          = featuresPat,
             emitversions      = featuresPat,
@@ -178,7 +182,7 @@ def makeGenOpts(args):
             filename          = 'vk_loader_extensions.h',
             directory         = directory,
             genpath           = None,
-            apiname           = defaultApiName,
+            apiname           = apiname,
             profile           = None,
             versions          = featuresPat,
             emitversions      = featuresPat,
@@ -202,7 +206,7 @@ def makeGenOpts(args):
             filename          = 'vk_loader_extensions.c',
             directory         = directory,
             genpath           = None,
-            apiname           = defaultApiName,
+            apiname           = apiname,
             profile           = None,
             versions          = featuresPat,
             emitversions      = featuresPat,
@@ -226,7 +230,7 @@ def makeGenOpts(args):
             filename          = 'vk_object_types.h',
             directory         = directory,
             genpath           = None,
-            apiname           = defaultApiName,
+            apiname           = apiname,
             profile           = None,
             versions          = featuresPat,
             emitversions      = featuresPat,
@@ -251,7 +255,7 @@ def makeGenOpts(args):
             filename          = 'loader_generated_header_version.cmake',
             directory         = directory,
             genpath           = None,
-            apiname           = defaultApiName,
+            apiname           = apiname,
             profile           = None,
             versions          = featuresPat,
             emitversions      = featuresPat,
@@ -290,6 +294,7 @@ def genTarget(args):
 
         if not args.quiet:
             write('* Building', options.filename, file=sys.stderr)
+            write('* options.apiname           =', options.apiname, file=sys.stderr)
             write('* options.versions          =', options.versions, file=sys.stderr)
             write('* options.emitversions      =', options.emitversions, file=sys.stderr)
             write('* options.defaultExtensions =', options.defaultExtensions, file=sys.stderr)
@@ -314,8 +319,12 @@ def genTarget(args):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
 
-    parser.add_argument('-defaultExtensions', action='store',
+    parser.add_argument('-api', action='store',
                         default='vulkan',
+                        choices=['vulkan', 'vulkansc'],
+                        help='Specify API name to generate')
+    parser.add_argument('-defaultExtensions', action='store',
+                        default=None,
                         help='Specify a single class of extensions to add to targets')
     parser.add_argument('-extension', action='append',
                         default=[],

--- a/tests/framework/icd/test_icd.cpp
+++ b/tests/framework/icd/test_icd.cpp
@@ -433,6 +433,20 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkGetPhysicalDeviceImageFormatProperties2(
     return VK_SUCCESS;
 }
 
+#if defined(VULKANSC)
+VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceExternalBufferProperties(
+    VkPhysicalDevice physicalDevice, const VkPhysicalDeviceExternalBufferInfo* pExternalBufferInfo,
+    VkExternalBufferProperties* pExternalBufferProperties) {}
+
+VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceExternalFenceProperties(VkPhysicalDevice physicalDevice,
+                                                                      const VkPhysicalDeviceExternalFenceInfo* pExternalFenceInfo,
+                                                                      VkExternalFenceProperties* pExternalFenceProperties) {}
+
+VKAPI_ATTR void VKAPI_CALL vkGetPhysicalDeviceExternalSemaphoreProperties(
+    VkPhysicalDevice physicalDevice, const VkPhysicalDeviceExternalSemaphoreInfo* pExternalSemaphoreInfo,
+    VkExternalSemaphoreProperties* pExternalSemaphoreProperties) {}
+#endif
+
 //// trampolines
 
 #define TO_VOID_PFN(func) reinterpret_cast<PFN_vkVoidFunction>(func)
@@ -549,6 +563,15 @@ PFN_vkVoidFunction get_physical_device_func(VkInstance instance, const char* pNa
         if (string_eq(pName, "vkGetPhysicalDeviceImageFormatProperties2")) {
             return TO_VOID_PFN(test_vkGetPhysicalDeviceImageFormatProperties2);
         }
+
+#if defined(VULKANSC)
+        if (string_eq(pName, "vkGetPhysicalDeviceExternalBufferProperties"))
+            return TO_VOID_PFN(vkGetPhysicalDeviceExternalSemaphoreProperties);
+        if (string_eq(pName, "vkGetPhysicalDeviceExternalFenceProperties"))
+            return TO_VOID_PFN(vkGetPhysicalDeviceExternalSemaphoreProperties);
+        if (string_eq(pName, "vkGetPhysicalDeviceExternalSemaphoreProperties"))
+            return TO_VOID_PFN(vkGetPhysicalDeviceExternalSemaphoreProperties);
+#endif
     }
 #if !defined(VULKANSC)
     if (icd.supports_tooling_info_ext) {

--- a/tests/framework/layer/test_layer.h
+++ b/tests/framework/layer/test_layer.h
@@ -33,6 +33,7 @@
 #include "layer/layer_util.h"
 
 #if defined(VULKANSC)
+#include "loader/vksc_header_wa.h"
 #include "loader/generated-vksc/vk_layer_dispatch_table.h"
 #else
 #include "loader/generated/vk_layer_dispatch_table.h"

--- a/tests/framework/layer/wrap_objects.cpp
+++ b/tests/framework/layer/wrap_objects.cpp
@@ -27,6 +27,7 @@
 
 #include "vulkan/vk_layer.h"
 #if defined(VULKANSC)
+#include "loader/vksc_header_wa.h"
 #include "loader/generated-vksc/vk_dispatch_table_helper.h"
 #else
 #include "loader/generated/vk_dispatch_table_helper.h"

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -456,6 +456,10 @@ inline std::ostream& operator<<(std::ostream& os, const VkResult& result) {
 #endif
         case (VK_RESULT_MAX_ENUM):
             return os << "VK_RESULT_MAX_ENUM";
+#if defined(VULKANSC)
+        default:
+            break;
+#endif
     }
     return os << static_cast<int32_t>(result);
 }


### PR DESCRIPTION
This PR contains all the necessary changes to make the Vulkan SC loader compatible with the latest Vulkan SC headers and tooling.

It should build with regular Vulkan SC headers, as well as with combined headers (needed due to the loader being a dependenccy of Vulkan-Tools, which itself is built with the combined headers).

It also contains a set of fixes for issues identified during the update, as well as a workaround for the current Vulkan SC 1.0.12 headers missing some definitions that are otherwise present in the latest `vk.xml` used by Vulkan SC. This workaround can be removed after the next spec patch release.