### PR TITLE
loader: Patch Vulkan SC variant to the version parsed from the JSON manifest

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -1822,6 +1822,12 @@ VkResult loader_scanned_icd_add(const struct loader_instance *inst, struct loade
 #endif
     new_scanned_icd->interface_version = interface_vers;
 
+#ifdef VULKANSC
+    // Add Vulkan SC API variant to the ICD API version manually, as we don't expect the JSON manifest
+    // to contain the API variant (we do not use the <variant>.<major>.<minor>.<patch> format).
+    new_scanned_icd->api_version |= VK_MAKE_API_VERSION(VKSC_API_VARIANT, 0, 0, 0);
+#endif  // VULKANSC
+
     res = loader_copy_to_new_str(inst, filename, &new_scanned_icd->lib_name);
     if (VK_ERROR_OUT_OF_HOST_MEMORY == res) {
         loader_log(inst, VULKAN_LOADER_ERROR_BIT, 0, "loader_scanned_icd_add: Out of memory can't add ICD %s", filename);

--- a/tests/framework/icd/test_icd.cpp
+++ b/tests/framework/icd/test_icd.cpp
@@ -192,6 +192,13 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateInstance(const VkInstanceCreateInfo*
         return VK_ERROR_OUT_OF_HOST_MEMORY;
     }
 
+#ifdef VULKANSC
+    if (pCreateInfo->pApplicationInfo->apiVersion != 0 &&
+        VK_API_VERSION_VARIANT(pCreateInfo->pApplicationInfo->apiVersion) != VKSC_API_VARIANT) {
+        return VK_ERROR_INCOMPATIBLE_DRIVER;
+    }
+#endif
+
     if (icd.icd_api_version < VK_API_VERSION_1_1) {
 #ifdef VULKANSC
         if (pCreateInfo->pApplicationInfo->apiVersion > VKSC_API_VERSION_1_0) {

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -706,7 +706,11 @@ struct InstanceCreateInfo {
     BUILDER_VALUE(InstanceCreateInfo, uint32_t, app_version, 0)
     BUILDER_VALUE(InstanceCreateInfo, uint32_t, engine_version, 0)
 #ifdef VULKANSC
-    BUILDER_VALUE(InstanceCreateInfo, uint32_t, api_version, VKSC_API_VERSION_1_0)
+    uint32_t api_version = VKSC_API_VERSION_1_0;
+    InstanceCreateInfo& set_api_version(uint32_t const& api_version) {
+        this->api_version = api_version | VK_MAKE_API_VERSION(VKSC_API_VARIANT, 0, 0, 0);
+        return *this;
+    }
 #else
     BUILDER_VALUE(InstanceCreateInfo, uint32_t, api_version, VK_API_VERSION_1_0)
 #endif  // VULKANSC


### PR DESCRIPTION
@zangold, @dgkoch, FYI.

I've included the patch, as well as some hardening in the tests.

I'm considering that we should adopt the same "auto-magic" API version class that we also use in the VVL and vulkaninfo/vulkanscinfo and use it in the loader too.

Having the version be in a "smart" class that knows about the mapping between Vulkan and Vulkan SC versions should help going forward.

But for now this should already improve test coverage.