### PR TITLE
loader: Disable Vulkan 1.0 version workaround

### DIFF
--- a/loader/loader.c
+++ b/loader/loader.c
@@ -5420,15 +5420,17 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateInstance(const VkInstanceCreateI
         }
 #endif  // VULKANSC
 
+#ifndef VULKANSC
+        // NOTE: The code below only applies to Vulkan as it is intended to handle the case
+        // when a Vulkan 1.0 ICD is used with the loader which supports newer versions.
+        // Vulkan 1.0 implementations were required to return VK_ERROR_INCOMPATIBLE_DRIVER
+        // if apiVersion was larger than 1.0, which is handled here by always passing down
+        // API version 1.0 to a Vulkan 1.0 ICD. This does not apply to Vulkan SC as Vulkan
+        // SC 1.0 is based on Vulkan 1.2 and does not need this compatibility workaround.
         // Create an instance, substituting the version to 1.0 if necessary
         VkApplicationInfo icd_app_info;
-#ifdef VULKANSC
-        const uint32_t api_variant = VKSC_API_VARIANT;
-        const uint32_t api_version_1_0 = VKSC_API_VERSION_1_0;
-#else
         const uint32_t api_variant = 0;
         const uint32_t api_version_1_0 = VK_API_VERSION_1_0;
-#endif  // VULKANSC
         uint32_t icd_version_nopatch =
             VK_MAKE_API_VERSION(api_variant, VK_API_VERSION_MAJOR(icd_version), VK_API_VERSION_MINOR(icd_version), 0);
         uint32_t requested_version = (pCreateInfo == NULL || pCreateInfo->pApplicationInfo == NULL)
@@ -5443,6 +5445,7 @@ VKAPI_ATTR VkResult VKAPI_CALL terminator_CreateInstance(const VkInstanceCreateI
             icd_app_info.apiVersion = icd_version;
             icd_create_info.pApplicationInfo = &icd_app_info;
         }
+#endif  // VULKANSC
         icd_result =
             ptr_instance->icd_tramp_list.scanned_list[i].CreateInstance(&icd_create_info, pAllocator, &(icd_term->instance));
         if (VK_ERROR_OUT_OF_HOST_MEMORY == icd_result) {

--- a/loader/trampoline.c
+++ b/loader/trampoline.c
@@ -605,11 +605,20 @@ LOADER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkCreateInstance(const VkInstanceCr
 
     // Providing an apiVersion less than VK_API_VERSION_1_0 but greater than zero prevents the validation layers from starting
     if (pCreateInfo->pApplicationInfo && pCreateInfo->pApplicationInfo->apiVersion != 0u &&
+#ifdef VULKANSC
+        VK_API_VERSION_VARIANT(pCreateInfo->pApplicationInfo->apiVersion) == VKSC_API_VARIANT &&
+        pCreateInfo->pApplicationInfo->apiVersion < VKSC_API_VERSION_1_0) {
+#else
         pCreateInfo->pApplicationInfo->apiVersion < VK_API_VERSION_1_0) {
+#endif
         loader_log(ptr_instance, VULKAN_LOADER_FATAL_ERROR_BIT | VULKAN_LOADER_ERROR_BIT, 0,
                    "VkInstanceCreateInfo::pApplicationInfo::apiVersion has value of %u which is not permitted. If apiVersion is "
                    "not 0, then it must be "
+#ifdef VULKANSC
+                   "greater than or equal to the value of VKSC_API_VERSION_1_0 [VUID-VkApplicationInfo-apiVersion]",
+#else
                    "greater than or equal to the value of VK_API_VERSION_1_0 [VUID-VkApplicationInfo-apiVersion]",
+#endif
                    pCreateInfo->pApplicationInfo->apiVersion);
     }
 

--- a/tests/framework/icd/test_icd.cpp
+++ b/tests/framework/icd/test_icd.cpp
@@ -188,22 +188,29 @@ VKAPI_ATTR VkResult VKAPI_CALL test_vkEnumerateInstanceVersion(uint32_t* pApiVer
 VKAPI_ATTR VkResult VKAPI_CALL test_vkCreateInstance(const VkInstanceCreateInfo* pCreateInfo,
                                                      [[maybe_unused]] const VkAllocationCallbacks* pAllocator,
                                                      VkInstance* pInstance) {
-    if (pCreateInfo == nullptr || pCreateInfo->pApplicationInfo == nullptr) {
+    if (pCreateInfo == nullptr) {
         return VK_ERROR_OUT_OF_HOST_MEMORY;
     }
 
 #ifdef VULKANSC
-    if (pCreateInfo->pApplicationInfo->apiVersion != 0 &&
-        VK_API_VERSION_VARIANT(pCreateInfo->pApplicationInfo->apiVersion) != VKSC_API_VARIANT) {
+    uint32_t default_api_version = VKSC_API_VERSION_1_0;
+#else
+    uint32_t default_api_version = VK_API_VERSION_1_0;
+#endif
+    uint32_t api_version =
+        (pCreateInfo->pApplicationInfo == nullptr) ? default_api_version : pCreateInfo->pApplicationInfo->apiVersion;
+
+#ifdef VULKANSC
+    if (api_version != 0 && VK_API_VERSION_VARIANT(api_version) != VKSC_API_VARIANT) {
         return VK_ERROR_INCOMPATIBLE_DRIVER;
     }
 #endif
 
     if (icd.icd_api_version < VK_API_VERSION_1_1) {
 #ifdef VULKANSC
-        if (pCreateInfo->pApplicationInfo->apiVersion > VKSC_API_VERSION_1_0) {
+        if (api_version > VKSC_API_VERSION_1_0) {
 #else
-        if (pCreateInfo->pApplicationInfo->apiVersion > VK_API_VERSION_1_0) {
+        if (api_version > VK_API_VERSION_1_0) {
 #endif
             return VK_ERROR_INCOMPATIBLE_DRIVER;
         }

--- a/tests/framework/test_util.cpp
+++ b/tests/framework/test_util.cpp
@@ -578,8 +578,11 @@ VkInstanceCreateInfo* InstanceCreateInfo::get() noexcept {
 }
 InstanceCreateInfo& InstanceCreateInfo::set_api_version(uint32_t major, uint32_t minor, uint32_t patch) {
 #ifdef VULKANSC
-    // Make sure to include Vulkan SC API variant in the requested API version
-    this->api_version = VK_MAKE_API_VERSION(VKSC_API_VARIANT, major, minor, patch);
+    if (major == 1 && minor <= 2) {
+        this->api_version = VK_MAKE_API_VERSION(VKSC_API_VARIANT, 1, 0, patch);
+    } else {
+        this->api_version = VK_MAKE_API_VERSION(VKSC_API_VARIANT, major, minor, patch);
+    }
 #else
     this->api_version = VK_MAKE_API_VERSION(0, major, minor, patch);
 #endif  // VULKANSC

--- a/tests/framework/test_util.h
+++ b/tests/framework/test_util.h
@@ -708,7 +708,11 @@ struct InstanceCreateInfo {
 #ifdef VULKANSC
     uint32_t api_version = VKSC_API_VERSION_1_0;
     InstanceCreateInfo& set_api_version(uint32_t const& api_version) {
-        this->api_version = api_version | VK_MAKE_API_VERSION(VKSC_API_VARIANT, 0, 0, 0);
+        if (VK_API_VERSION_MAJOR(api_version) == 1 && VK_API_VERSION_MINOR(api_version) <= 2) {
+            this->api_version = VK_MAKE_API_VERSION(VKSC_API_VARIANT, 1, 0, VK_API_VERSION_PATCH(api_version));
+        } else {
+            this->api_version = api_version | VK_MAKE_API_VERSION(VKSC_API_VARIANT, 0, 0, 0);
+        }
         return *this;
     }
 #else

--- a/tests/loader_regression_tests.cpp
+++ b/tests/loader_regression_tests.cpp
@@ -134,12 +134,23 @@ TEST(CreateInstance, ApiVersionBelow1_0) {
     DebugUtilsLogger debug_log{VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT};
     InstWrapper inst{env.vulkan_functions};
     FillDebugUtilsCreateDetails(inst.create_info, debug_log);
+#ifdef VULKANSC
+    inst.create_info.api_version = VK_MAKE_API_VERSION(VKSC_API_VARIANT, 0, 0, 1);
+#else
     inst.create_info.api_version = 1;
+#endif
     inst.CheckCreate();
+#ifdef VULKANSC
+    ASSERT_TRUE(debug_log.find(
+        "VkInstanceCreateInfo::pApplicationInfo::apiVersion has value of 536870913 which is not permitted. If apiVersion is "
+        "not 0, then it must be "
+        "greater than or equal to the value of VKSC_API_VERSION_1_0 [VUID-VkApplicationInfo-apiVersion]"));
+#else
     ASSERT_TRUE(
         debug_log.find("VkInstanceCreateInfo::pApplicationInfo::apiVersion has value of 1 which is not permitted. If apiVersion is "
                        "not 0, then it must be "
                        "greater than or equal to the value of VK_API_VERSION_1_0 [VUID-VkApplicationInfo-apiVersion]"));
+#endif
 }
 
 TEST(CreateInstance, ConsecutiveCreate) {


### PR DESCRIPTION
@zangold, this is the fix we created based on your suggestion in https://github.com/KhronosGroup/VulkanSC-Loader/pull/44.

Please verify that this fix addresses the issue you've encountered.